### PR TITLE
Added lazy depthimage_to_laserscan to 3dsensor.launch

### DIFF
--- a/turtlebot_bringup/launch/3dsensor.launch
+++ b/turtlebot_bringup/launch/3dsensor.launch
@@ -52,11 +52,13 @@
     </include>
   </group>
 
-  <!-- throttling -->
-  <node pkg="nodelet" type="nodelet" name="pointcloud_throttle" args="load pointcloud_to_laserscan/CloudThrottle $(arg camera)_nodelet_manager" respawn="true">
-    <param name="max_rate" value="20.0"/>
-    <remap from="cloud_in" to="/camera/depth/points"/>
-    <remap from="cloud_out" to="cloud_throttled"/>
+  <!-- Launch depthimage_to_laserscan -->
+  <!-- This uses lazy subscribing, so will not activate Asus/Kinect until scan is requested. -->
+  <node pkg="nodelet" type="nodelet" name="depthimage_to_laserscan" args="load depthimage_to_laserscan/DepthImageToLaserScanNodelet $(arg camera)_nodelet_manager">
+    <param name="output_frame_id" value="/$(arg camera)_depth_frame"/>
+    <param name="range_min" value="0.6"/>
+    <remap from="image" to="/$(arg camera)/depth/image_raw"/>
+    <remap from="scan" to="/$(arg camera)/scan" />
   </node>
 </launch>
 


### PR DESCRIPTION
Since the depthimage_to_laserscan is lazy, it will not activate the Kinect until /camera/scan is subscribed to.  There is no harm in leaving the topic advertised under the 3dsensor.launch file.  Any apps that used to launch pointcloud_to_laserscan should have that line removed.
