### PR TITLE
Fixed turtlebot.launch file used by upstart scripts

### DIFF
--- a/turtlebot_bringup/upstart/turtlebot.launch
+++ b/turtlebot_bringup/upstart/turtlebot.launch
@@ -5,8 +5,6 @@
   <param name="turtlebot_node/gyro_scale_correction" value="1.0"/>
   <param name="turtlebot_node/odom_angular_scale_correction" value="1.0"/>
 
-  <include file="$(find turtlebot_bringup)/minimal.launch">
-    <arg name="urdf_file" value="$(find xacro)/xacro.py '$(find turtlebot_description)/robots/turtlebot.urdf.xacro'" />
-  </include>
+  <include file="$(find turtlebot_bringup)/launch/minimal.launch"/>
 
 </launch>


### PR DESCRIPTION
Removed obsolete argument and fixed path for minimal.launch.
