### PR TITLE
Roomba support

### DIFF
--- a/turtlebot_bringup/launch/includes/roomba/_mobile_base.launch
+++ b/turtlebot_bringup/launch/includes/roomba/_mobile_base.launch
@@ -1,0 +1,36 @@
+<!--
+  Create's implementation of turtlebot's mobile base.
+  
+  TODO: redirect cmd_vel_mux/output to wherever create base is listening.
+ -->
+<launch>
+  <!-- Turtlebot Driver -->
+  <node pkg="create_node" type="turtlebot_node.py" name="turtlebot_node" respawn="true" args="--respawnable">
+    <param name="robot_type" value="roomba" />
+    <param name="has_gyro" value="false" />
+    <param name="bonus" value="false" />
+    <param name="update_rate" value="30.0" />
+  </node>
+  
+  <!-- Enable breaker 1 for the kinect -->
+  <!--node pkg="create_node" type="kinect_breaker_enabler.py" name="kinect_breaker_enabler"/-->
+  
+  <!-- The odometry estimator -->
+  <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
+    <remap from="imu_data" to="imu/data"/>
+    <param name="freq" value="10.0"/>
+    <param name="sensor_timeout" value="1.0"/>
+    <param name="publish_tf" value="true"/>
+    <param name="odom_used" value="true"/>
+    <param name="imu_used" value="true"/>
+    <param name="vo_used" value="false"/>
+    <param name="output_frame" value="odom"/>
+  </node>
+
+  <!-- velocity commands multiplexer -->
+  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
+  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
+    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
+    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
+  </node>
+</launch>

--- a/turtlebot_bringup/param/roomba/diagnostics.yaml
+++ b/turtlebot_bringup/param/roomba/diagnostics.yaml
@@ -1,0 +1,28 @@
+pub_rate: 1.0 # Optional
+base_path: '' # Optional, prepended to all diagnostic output
+analyzers:
+  nodes: 
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Nodes'
+    timeout: 5.0
+    contains: ['Node']
+  mode:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Mode'
+    timeout: 5.0
+    startswith: ['Operating Mode']
+  sensors: 
+    type: GenericAnalyzer
+    path: 'Sensors'
+    timeout: 5.0
+    startswith: ['Cliff Sensor', 'Wall Sensor', 'Gyro Sensor']
+  power:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Power System'
+    timeout: 5.0
+    startswith: ['Battery', 'Charging Sources', 'Laptop Battery']
+  digital_io:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Digital IO'
+    timeout: 5.0
+    startswith: ['Digital Outputs']

--- a/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+    - Base      : create
+    - Stacks    : circles
+    - 3d Sensor : kinect
+-->    
+<robot name="turtlebot"
+       xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+
+  <create/>
+  <stack_circles parent="base_link"/>
+  <sensor_asus_xtion_pro  parent="base_link"/>
+</robot>

--- a/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+    - Base      : create
+    - Stacks    : circles
+    - 3d Sensor : kinect
+-->    
+<robot name="turtlebot"
+       xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+
+  <create/>
+  <stack_circles parent="base_link"/>
+  <sensor_kinect  parent="base_link"/>
+</robot>


### PR DESCRIPTION
I have been trying to use the new groovy turtlebot packages with iRobot Roomba recently and found out that some XML files are missing in order to get the minimal.launch to run. For now I have simply copied the create files and renamed them appropriately and this works (with some adjustment to other packages in other repositories ... I will request merge there as well). I think this is the cleanest way to enable Roomba support that already exists in the python driver and I hope it will be accepted as Roomba support is very important for European turtlebot users.
