### PR TITLE
prefix test target to not collide with other targets

### DIFF
--- a/turtlebot_description/CMakeLists.txt
+++ b/turtlebot_description/CMakeLists.txt
@@ -20,5 +20,5 @@ install(DIRECTORY urdf
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-catkin_add_gtest(test_urdf test/test_urdf.cpp)
+catkin_add_gtest(${PROJECT_NAME}_test_urdf test/test_urdf.cpp)
 


### PR DESCRIPTION
Please release fixed version into Hydro since this currently blocks building all Hydro packages in a single workspace.
