### PR TITLE
Added serial port as parameter to launch files (Issue https://github.com/turtlebot/turtlebot/issues/111)

### DIFF
--- a/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
@@ -4,11 +4,13 @@
   TODO: redirect cmd_vel_mux/output to wherever create base is listening.
  -->
 <launch>
+  <arg name="serialport"/>
+  
   <!-- Turtlebot Driver -->
   <node pkg="create_node" type="turtlebot_node.py" name="turtlebot_node" respawn="true" args="--respawnable">
     <param name="bonus" value="false" />
     <param name="update_rate" value="30.0" />
-    <param name="port" value="/dev/ttyUSB0" />
+    <param name="port" value="$(arg serialport)" />
     <remap from="cmd_vel" to="mobile_base/commands/velocity" />
     <remap from="turtlebot_node/sensor_state" to="mobile_base/sensors/core" />
     <remap from="imu/data" to="mobile_base/sensors/imu_data" />

--- a/turtlebot_bringup/launch/includes/kobuki/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/kobuki/mobile_base.launch.xml
@@ -2,6 +2,8 @@
   Kobuki's implementation of turtlebot's mobile base.
  -->
 <launch>
+  <arg name="serialport"/> <!-- TODO: use the serialport parameter to set the serial port of kobuki -->
+  
   <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
   <node pkg="nodelet" type="nodelet" name="mobile_base" args="load kobuki_node/KobukiNodelet mobile_base_nodelet_manager">
     <rosparam file="$(find kobuki_node)/param/base.yaml" command="load"/>

--- a/turtlebot_bringup/launch/includes/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/mobile_base.launch.xml
@@ -5,6 +5,9 @@
  -->
 <launch>
   <arg name="base"/>
-  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml"/>
+  <arg name="serialport"/>
+  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
+    <arg name="serialport" value="$(arg serialport)" />
+  </include>
 </launch>
 

--- a/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
@@ -4,12 +4,15 @@
   TODO: redirect cmd_vel_mux/output to wherever create base is listening.
  -->
 <launch>
+  <arg name="serialport"/>
+
   <!-- Turtlebot Driver -->
   <node pkg="create_node" type="turtlebot_node.py" name="turtlebot_node" respawn="true" args="--respawnable">
     <param name="robot_type" value="roomba" />
     <param name="has_gyro" value="false" />
     <param name="bonus" value="false" />
     <param name="update_rate" value="30.0" />
+    <param name="port" value="$(arg serialport)" />
     <remap from="cmd_vel" to="mobile_base/commands/velocity" />
     <remap from="turtlebot_node/sensor_state" to="mobile_base/sensors/core" />
     <remap from="imu/data" to="mobile_base/sensors/imu_data" />

--- a/turtlebot_bringup/launch/minimal.launch
+++ b/turtlebot_bringup/launch/minimal.launch
@@ -4,6 +4,7 @@
   <arg name="stacks"     default="$(optenv TURTLEBOT_STACKS hexagons)"/>  <!-- circles, hexagons -->
   <arg name="3d_sensor"  default="$(optenv TURTLEBOT_3D_SENSOR kinect)"/>  <!-- kinect, asus_xtion_pro -->
   <arg name="simulation" default="$(optenv TURTLEBOT_SIMULATION false)"/>
+  <arg name="serialport" default="$(optenv TURTLEBOT_SERIAL_PORT /dev/ttyUSB0)"/>
 
   <param name="/use_sim_time" value="$(arg simulation)"/>
   
@@ -14,6 +15,7 @@
   </include>
   <include file="$(find turtlebot_bringup)/launch/includes/mobile_base.launch.xml">
     <arg name="base" value="$(arg base)" />
+    <arg name="serialport" value="$(arg serialport)" />
   </include>
   <include file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
     <arg name="battery" value="$(arg battery)" />


### PR DESCRIPTION
Allows to set the environmental variable TURTLEBOT_SERIAL_PORT that is used as serial port in all launch files (TODO: kobuki/mobile_base.launch.xml).

```
modified:   create/mobile_base.launch.xml
modified:   kobuki/mobile_base.launch.xml
modified:   mobile_base.launch.xml
modified:   roomba/mobile_base.launch.xml
modified:   ../minimal.launch
```

Committer: mayrjohannes joh.mayr@jku.at
Author: mayrjohannes joh.mayr@jku.at
