### PR TITLE
Fixing "Error with diagnostics.yaml for roomba #110"

### DIFF
--- a/turtlebot_bringup/param/roomba/diagnostics.yaml
+++ b/turtlebot_bringup/param/roomba/diagnostics.yaml
@@ -1,1 +1,28 @@
-../create/diagnostics.yaml
+pub_rate: 1.0 # Optional
+base_path: '' # Optional, prepended to all diagnostic output
+analyzers:
+  nodes: 
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Nodes'
+    timeout: 5.0
+    contains: ['Node']
+  mode:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Mode'
+    timeout: 5.0
+    startswith: ['Operating Mode']
+  sensors: 
+    type: GenericAnalyzer
+    path: 'Sensors'
+    timeout: 5.0
+    startswith: ['Cliff Sensor', 'Wall Sensor', 'Gyro Sensor']
+  power:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Power System'
+    timeout: 5.0
+    startswith: ['Battery', 'Charging Sources', 'Laptop Battery']
+  digital_io:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'Digital IO'
+    timeout: 5.0
+    startswith: ['Digital Outputs']


### PR DESCRIPTION
Here is a commit that should fix #110. As it is mentioned in the issue the only thing to do is to copy the diagnostics.yaml from create directory to roomba directory.
