### PR TITLE
add depth argument to configure scan_processing. With this configuration...

### DIFF
--- a/turtlebot_bringup/launch/3dsensor.launch
+++ b/turtlebot_bringup/launch/3dsensor.launch
@@ -21,6 +21,8 @@
 
   <!-- Factory-calibrated depth registration -->
   <arg name="depth_registration"              default="true"/>
+  <arg     if="$(arg depth_registration)" name="depth" value="depth_registered" />
+  <arg unless="$(arg depth_registration)" name="depth" value="depth" />
 
   <!-- Processing Modules -->
   <arg name="rgb_processing"                  default="true"/>
@@ -62,13 +64,13 @@
       <param name="scan_height" value="10"/>
       <param name="output_frame_id" value="/$(arg camera)_depth_frame"/>
       <param name="range_min" value="0.45"/>
-      <remap from="image" to="$(arg camera)/depth/image_raw"/>
+      <remap from="image" to="$(arg camera)/$(arg depth)/image_raw"/>
       <remap from="scan" to="$(arg scan_topic)"/>
 
       <!-- Somehow topics here get prefixed by "$(arg camera)" when not inside an app namespace,
            so in this case "$(arg scan_topic)" must provide an absolute topic name (issue #88).
            Probably is a bug in the nodelet manager: https://github.com/ros/nodelet_core/issues/7 -->
-      <remap from="$(arg camera)/image" to="$(arg camera)/depth/image_raw"/>
+      <remap from="$(arg camera)/image" to="$(arg camera)/$(arg depth)/image_raw"/>
       <remap from="$(arg camera)/scan" to="$(arg scan_topic)"/>
     </node>
   </group>


### PR DESCRIPTION
... scan works for both depth_regratation false and true

It is related with #128 and it resolved #123

scan topic name configuration topic naming using argument existed in groovy but somehow it disappeared in hydro.

_Groovy_
https://github.com/turtlebot/turtlebot/blob/groovy/turtlebot_bringup/launch/3dsensor.launch#L24-L26
https://github.com/turtlebot/turtlebot/blob/groovy/turtlebot_bringup/launch/3dsensor.launch#L83-L90

Hydro : 
https://github.com/turtlebot/turtlebot/blob/hydro/turtlebot_bringup/launch/3dsensor.launch#L22-L23
https://github.com/turtlebot/turtlebot/blob/hydro/turtlebot_bringup/launch/3dsensor.launch#L59-L73
