### PR TITLE
Check if unit-testing is enabled

### DIFF
--- a/turtlebot_description/CMakeLists.txt
+++ b/turtlebot_description/CMakeLists.txt
@@ -20,5 +20,9 @@ install(DIRECTORY urdf
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-catkin_add_gtest(${PROJECT_NAME}_test_urdf test/test_urdf.cpp)
+if(CATKIN_ENABLE_TESTING)
+
+	catkin_add_gtest(${PROJECT_NAME}_test_urdf test/test_urdf.cpp)
+
+endif()
 


### PR DESCRIPTION
CATKIN_ENABLE_TESTING is a late addtion to catkin. This updates the
package to comply with the strict checking rule.
