### PR TITLE
Load any calibration files during create bringup

### DIFF
--- a/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
@@ -20,6 +20,9 @@
   <!-- Enable breaker 1 for the kinect -->
   <node pkg="create_node" type="kinect_breaker_enabler.py" name="kinect_breaker_enabler"/>
 
+  <!-- Load create and gyro calibration  -->
+  <node pkg="create_node" type="load_calib.py" name="create_load_calibration"/>
+
   <!-- The odometry estimator -->
   <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
     <remap from="imu_data" to="mobile_base/sensors/imu_data"/>

--- a/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
@@ -21,7 +21,9 @@
   <node pkg="create_node" type="kinect_breaker_enabler.py" name="kinect_breaker_enabler"/>
 
   <!-- Load create and gyro calibration  -->
-  <node pkg="create_node" type="load_calib.py" name="create_load_calibration"/>
+  <node pkg="create_node" type="load_calib.py" name="create_load_calibration">
+    <remap from="cmd_vel" to="mobile_base/commands/velocity" />
+  </node>
 
   <!-- The odometry estimator -->
   <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">


### PR DESCRIPTION
Load any available calibration files for the attached Create during bringup.  See the following pull request for more information:  https://github.com/turtlebot/turtlebot_create/pull/14

Note, this pull request depends on that one, please don't apply until it is accepted.
