### PR TITLE
Enable the kinect heuristics by default for gmapping

### DIFF
--- a/turtlebot_bringup/launch/3dsensor.launch
+++ b/turtlebot_bringup/launch/3dsensor.launch
@@ -64,6 +64,7 @@
       <param name="scan_height" value="10"/>
       <param name="output_frame_id" value="/$(arg camera)_depth_frame"/>
       <param name="range_min" value="0.45"/>
+      <param name="kinect_heuristics" value="true"/>
       <remap from="image" to="$(arg camera)/$(arg depth)/image_raw"/>
       <remap from="scan" to="$(arg scan_topic)"/>
 


### PR DESCRIPTION
When doing gmapping our kinect heuristics patch greatly helps map large spaces.  See here for more information: https://github.com/ros-perception/depthimage_to_laserscan/pull/9

This pull depends on that one, please do not merge until after depthimage_to_laserscan has been updated.
