### PR TITLE
Issue #172: Provide mass and inertia real values for 3D camera/stacks/poles

### DIFF
--- a/turtlebot_description/scripts/calc_inertia.m
+++ b/turtlebot_description/scripts/calc_inertia.m
@@ -1,0 +1,86 @@
+% Calculate moments of inertia for 3D sensors and TB2 poles and stacks.
+% Formulas extracted from: http://en.wikipedia.org/wiki/List_of_moments_of_inertia
+% TODO: do also for turtlebot 1 poles and stacks.
+
+% Poles are approximated as solid cylinder of radius r, height h and mass m
+
+% Base poles
+m = 0.008;
+r = 0.006;
+h = 0.0492;
+
+Ix = (m*(3*r^2 + h^2))/12
+Iy = Ix
+Iz = (m*r^2)/2
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+% Middle poles
+m = 0.012;
+r = 0.006;
+h = 0.0608;
+
+Ix = (m*(3*r^2 + h^2))/12
+Iy = Ix
+Iz = (m*r^2)/2
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+% Long poles
+m = 0.060;
+r = 0.006;
+h = 0.2032;
+
+Ix = (m*(3*r^2 + h^2))/12
+Iy = Ix
+Iz = (m*r^2)/2
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+% Kinect poles
+m = 0.020;
+r = 0.006;
+h = 0.0936;  % not really... are much shorter!
+
+Ix = (m*(3*r^2 + h^2))/12
+Iy = Ix
+Iz = (m*r^2)/2
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+
+% Plates, approximated as a thin, solid disk of radius r and mass m:
+m = 0.520;
+r = 0.160;
+
+Ix = (m*r^2)/4
+Iy = Ix
+Iz = (m*r^2)/2
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+% Cameras, approximated as a solid cuboid of height h, width w, and depth d, and mass m:
+
+% Kinect
+m = 0.564;
+h = 0.073;
+w = 0.27794;
+d = 0.07271;
+
+Ix = (m*(w^2 + h^2))/12
+Iy = (m*(h^2 + d^2))/12
+Iz = (m*(w^2 + d^2))/12
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)
+
+% Asus
+m = 0.170;
+h = 0.072;
+w = 0.276;
+d = 0.073;
+
+Ix = (m*(w^2 + h^2))/12
+Iy = (m*(h^2 + d^2))/12
+Iz = (m*(w^2 + d^2))/12
+
+fprintf('%.9f\n%.9f\n%.9f\n', Ix, Iy, Iz)

--- a/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
@@ -16,32 +16,14 @@
       <parent link="${parent}"/>
       <child link="camera_rgb_frame" />
     </joint>
-
-    <link name="camera_rgb_frame">
-      <inertial>
-        <mass value="0.001" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-          iyy="0.0001" iyz="0.0"
-          izz="0.0001" />
-      </inertial>
-    </link>
+    <link name="camera_rgb_frame"/>
 
     <joint name="camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
       <parent link="camera_rgb_frame" />
       <child link="camera_rgb_optical_frame" />
     </joint>
-
-    <link name="camera_rgb_optical_frame">
-      <inertial>
-        <mass value="0.001" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-          iyy="0.0001" iyz="0.0"
-          izz="0.0001" />
-      </inertial>
-    </link>
+    <link name="camera_rgb_optical_frame"/>
 
     <joint name="camera_joint" type="fixed">
       <origin xyz="0 ${asus_xtion_pro_cam_rel_rgb_py} 0" 
@@ -59,15 +41,15 @@
       <collision>
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
         <geometry>
-        <box size="0.0730 .2760 0.0720"/>
+        <box size="0.0730 0.2760 0.0720"/>
       </geometry>
       </collision>
       <inertial>
-        <mass value="0.01" />
+        <mass value="0.170" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.001" ixy="0.0" ixz="0.0"
-          iyy="0.001" iyz="0.0"
-          izz="0.001" />
+        <inertia ixx="0.001152600" ixy="0.0" ixz="0.0"
+                 iyy="0.000148934" iyz="0.0"
+                 izz="0.001154654" />
       </inertial>
     </link>
 
@@ -76,34 +58,16 @@
       <parent link="camera_rgb_frame" />
       <child link="camera_depth_frame" />
     </joint>
-
-    <link name="camera_depth_frame">
-      <inertial>
-        <mass value="0.01" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.001" ixy="0.0" ixz="0.0"
-          iyy="0.001" iyz="0.0"
-          izz="0.001" />
-      </inertial>
-    </link>
+    <link name="camera_depth_frame"/>
 
     <joint name="camera_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
       <parent link="camera_depth_frame" />
       <child link="camera_depth_optical_frame" />
     </joint>
+    <link name="camera_depth_optical_frame"/>
 
-    <link name="camera_depth_optical_frame">
-      <inertial>
-        <mass value="0.001" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-          iyy="0.0001" iyz="0.0"
-          izz="0.0001" />
-      </inertial>
-    </link>
-
-  <!-- RGBD sensor for simulation, same as Kinect -->
-  <turtlebot_sim_3dsensor/>
+    <!-- RGBD sensor for simulation, same as Kinect -->
+    <turtlebot_sim_3dsensor/>
   </xacro:macro>
 </robot>

--- a/turtlebot_description/urdf/sensors/kinect.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/kinect.urdf.xacro
@@ -10,88 +10,58 @@
       <parent link="${parent}"/>
       <child link="camera_rgb_frame" />
     </joint>
-    <link name="camera_rgb_frame">
-      <inertial>
-        <mass value="0.001" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001" />
-      </inertial>
-    </link>
+    <link name="camera_rgb_frame"/>
+
     <joint name="camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
       <parent link="camera_rgb_frame" />
       <child link="camera_rgb_optical_frame" />
     </joint>
-    <link name="camera_rgb_optical_frame">
+    <link name="camera_rgb_optical_frame"/>
+
+    <joint name="camera_joint" type="fixed">
+      <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
+      <parent link="camera_rgb_frame"/>
+      <child link="camera_link"/>
+    </joint>  
+      <link name="camera_link">
+      <visual>
+       <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
+        <geometry>
+         <mesh filename="package://turtlebot_description/meshes/sensors/kinect.dae"/>
+        </geometry>
+      </visual>
+  	  <collision>
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+  	    <geometry>
+  	      <box size="0.07271 0.27794 0.073"/>
+  	    </geometry>
+  	  </collision>
       <inertial>
-        <mass value="0.001" />
+        <mass value="0.564" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001" />
+        <inertia ixx="0.003881243" ixy="0.0" ixz="0.0"
+                 iyy="0.000498940" iyz="0.0"
+                 izz="0.003879257" />
       </inertial>
     </link>
 
-  <joint name="camera_joint" type="fixed">
-    <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
-    <parent link="camera_rgb_frame"/>
-    <child link="camera_link"/>
-  </joint>  
-    <link name="camera_link">
-    <visual>
-     <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
-      <geometry>
-       <mesh filename="package://turtlebot_description/meshes/sensors/kinect.dae"/>
-      </geometry>
-    </visual>
-	  <collision>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
-	    <geometry>
-	      <box size="0.07271 0.27794 0.073"/>
-	    </geometry>
-	  </collision>
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-  </link>
-	  
-  <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch 
-       files. However, for Gazebo simulation we need them, so we add them here.
-       (Hence, don't publish them additionally!) -->
+    <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch 
+         files. However, for Gazebo simulation we need them, so we add them here.
+         (Hence, don't publish them additionally!) -->
 	<joint name="camera_depth_joint" type="fixed">
 	  <origin xyz="0 ${2 * -cam_py} 0" rpy="0 0 0" />
 	  <parent link="camera_rgb_frame" />
 	  <child link="camera_depth_frame" />
 	</joint>
-	<link name="camera_depth_frame">
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-	</link>
+	<link name="camera_depth_frame"/>
+
 	<joint name="camera_depth_optical_joint" type="fixed">
 	  <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
 	  <parent link="camera_depth_frame" />
 	  <child link="camera_depth_optical_frame" />
 	</joint>
-	<link name="camera_depth_optical_frame">
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-	</link>
+	<link name="camera_depth_optical_frame"/>
 	
 	<!-- Kinect sensor for simulation -->
 	<turtlebot_sim_3dsensor/>

--- a/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
+++ b/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
@@ -26,15 +26,15 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="0.0492" radius=".006"/>
+          <cylinder length="0.0492" radius="0.006"/>
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.001"/>
+        <mass value="0.008"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001"/>
+        <inertia ixx="0.000001686" ixy="0.0" ixz="0.0"
+                 iyy="0.000001686" iyz="0.0"
+                 izz="0.000000144"/>
       </inertial>
     </link>
   </xacro:macro>
@@ -55,15 +55,15 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="0.0608" radius=".006"/>
+          <cylinder length="0.0608" radius="0.006"/>
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.001"/>
+        <mass value="0.012"/>
         <origin xyz="0 0 0"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001"/>
+        <inertia ixx="0.000003805" ixy="0.0" ixz="0.0"
+                 iyy="0.000003805" iyz="0.0"
+                 izz="0.000000216"/>
       </inertial>
     </link>
   </xacro:macro>
@@ -84,15 +84,15 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="0.2032" radius=".006"/>
+          <cylinder length="0.2032" radius="0.006"/>
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.001"/>
+        <mass value="0.060"/>
         <origin xyz="0 0 0"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001"/>
+        <inertia ixx="0.000206991" ixy="0.0" ixz="0.0"
+                 iyy="0.000206991" iyz="0.0"
+                 izz="0.000001080"/>
       </inertial>
     </link>
   </xacro:macro>
@@ -106,7 +106,6 @@
     <link name="pole_kinect_${number}_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
-<!--         <origin xyz="0 0 0" rpy="${-M_PI/2} ${M_PI} 0"/> -->
         <geometry>
           <mesh filename="package://turtlebot_description/meshes/stacks/hexagons/pole_kinect.dae"/>
         </geometry>
@@ -118,15 +117,15 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.001"/>
+        <mass value="0.020"/>
         <origin xyz="0 0 0"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001"/>
+        <inertia ixx="0.000014782" ixy="0.0" ixz="0.0"
+                 iyy="0.000014782" iyz="0.0"
+                 izz="0.000000360"/>
       </inertial>
     </link>
   </xacro:macro>
-  
+
   <!-- 
     Stack macro - all the components relative transforms are made with respect 
     to the parent link (usually base_link). They could be made relative to each
@@ -159,11 +158,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.01" />
+        <mass value="0.520" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0"
-                 izz="0.01" />
+        <inertia ixx="0.003328" ixy="0.0" ixz="0.0"
+                 iyy="0.003328" iyz="0.0"
+                 izz="0.006656" />
       </inertial>
     </link>
     
@@ -191,11 +190,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.01" />
+        <mass value="0.520" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0"
-                 izz="0.01" />
+        <inertia ixx="0.003328" ixy="0.0" ixz="0.0"
+                 iyy="0.003328" iyz="0.0"
+                 izz="0.006656" />
       </inertial>  
     </link>
     
@@ -225,11 +224,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.01"/>
+        <mass value="0.520"/>
         <origin xyz="0 0 0"/>
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0"
-                 izz="0.01" />
+        <inertia ixx="0.003328" ixy="0.0" ixz="0.0"
+                 iyy="0.003328" iyz="0.0"
+                 izz="0.006656" />
       </inertial>
     </link>
   </xacro:macro>


### PR DESCRIPTION
I also simplified the "virtual" links (optical axes, etc.) by removing useless inertial tags.

Still to do for turtlebot 1 poles and stacks, but I cannot find mass and dimensions.

The masses are not very accurate, admittedly. But should be enough for a realistic simulation.
