### PR TITLE
remove old rosbuild imports no longer necessary

### DIFF
--- a/turtlebot_teleop/scripts/turtlebot_teleop_key
+++ b/turtlebot_teleop/scripts/turtlebot_teleop_key
@@ -27,8 +27,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import roslib
-roslib.load_manifest('turtlebot_teleop')
 import rospy
 
 from geometry_msgs.msg import Twist


### PR DESCRIPTION
These are no longer necessary. 
