### PR TITLE
add the follower switch mux to the default mux options

### DIFF
--- a/turtlebot_bringup/param/mux.yaml
+++ b/turtlebot_bringup/param/mux.yaml
@@ -18,6 +18,10 @@ subscribers:
     topic:       "input/teleop"
     timeout:     1.0
     priority:    7
+  - name:        "Switch"
+    topic:       "input/switch"
+    timeout:     1.0
+    priority:    6
   - name:        "Navigation"
     topic:       "input/navi"
     timeout:     1.0


### PR DESCRIPTION
This will include the follower disable mux by default. Needed for turtlebot/turtlebot_apps#144
