### PR TITLE
disable the battery node if TURTLEBOT_BATTERY is set to None

### DIFF
--- a/turtlebot_bringup/launch/concert_client.launch
+++ b/turtlebot_bringup/launch/concert_client.launch
@@ -20,7 +20,7 @@
     <arg name="base" value="$(arg base)" />
     <arg name="serialport" value="$(arg serialport)" />
   </include>
-  <include file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
+  <include unless="$(eval arg('battery') == 'None')" file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
     <arg name="battery" value="$(arg battery)" />
   </include>
 

--- a/turtlebot_bringup/launch/minimal.launch
+++ b/turtlebot_bringup/launch/minimal.launch
@@ -20,7 +20,7 @@
     <arg name="base" value="$(arg base)" />
     <arg name="serialport" value="$(arg serialport)" />
   </include>
-  <include file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
+  <include unless="$(eval arg('battery') == 'None')" file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">
     <arg name="battery" value="$(arg battery)" />
   </include>
 


### PR DESCRIPTION
Fixes #224 

This takes advantage of the new roslaunch `$(eval ...)` syntax so is kinetic specific and forces a fork of development. Thus this is against a new kinetic branch. 
