### PR TITLE
Refactor urdf.xacro files (indigo)

### DIFF
--- a/turtlebot_description/robots/create_circles_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/create_circles_asus_xtion_pro.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find create_description)/urdf/create.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
 
   <create/>
   <stack_circles parent="base_link"/>

--- a/turtlebot_description/robots/create_circles_kinect.urdf.xacro
+++ b/turtlebot_description/robots/create_circles_kinect.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find create_description)/urdf/create.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
 
   <create/>
   <stack_circles parent="base_link"/>

--- a/turtlebot_description/robots/kobuki_hexagons_astra.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_astra.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/astra.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons parent="base_link"/>

--- a/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons                 parent="base_link"/>

--- a/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro_offset.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro_offset.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro_offset.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons                 parent="base_link"/>

--- a/turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons parent="base_link"/>

--- a/turtlebot_description/robots/kobuki_hexagons_r200.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_r200.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/r200.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons parent="base_link"/>

--- a/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find create_description)/urdf/create.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
 
   <create/>
   <stack_circles parent="base_link"/>

--- a/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find create_description)/urdf/create.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
 
   <create/>
   <stack_circles parent="base_link"/>

--- a/turtlebot_description/urdf/turtlebot_common_library.urdf.xacro
+++ b/turtlebot_description/urdf/turtlebot_common_library.urdf.xacro
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--
+  The common turtlebot library of xacros for easy reference
+ -->
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- General -->
+  <xacro:include filename="$(find turtlebot_description)/urdf/common_properties.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_properties.urdf.xacro"/>
+</robot>


### PR DESCRIPTION
Refactor urdf.xacro files to stop loading unnecessary content.

Currently, every robot configuration (e.g.,
turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro)
simply includes a catch-all turtlebot_library.urdf.xacro file.
This file includes EVERY base, stacks, and sensor combination,
and thus a lot of unnecessary data is loaded into memory.

Refactored the turtlebot_library.urdf.xacro to include only
the data common to all turtlebot configurations, and modified
each robot configuration file to include only the additional base,
stacks, and sensor urdf files that apply.

Note: a mirrored PR exists for the Kinetic branch.