### PR TITLE
Remove concert reference to mobile_base.launch

### DIFF
--- a/turtlebot_bringup/launch/concert_client.launch
+++ b/turtlebot_bringup/launch/concert_client.launch
@@ -16,8 +16,7 @@
     <arg name="stacks" value="$(arg stacks)" />
     <arg name="3d_sensor" value="$(arg 3d_sensor)" />
   </include>
-  <include file="$(find turtlebot_bringup)/launch/includes/mobile_base.launch.xml">
-    <arg name="base" value="$(arg base)" />
+  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
     <arg name="serialport" value="$(arg serialport)" />
   </include>
   <include file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">

--- a/turtlebot_bringup/launch/includes/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/mobile_base.launch.xml
@@ -1,0 +1,16 @@
+<!--
+  The mobile platform base.
+  
+  Selector for the base.
+  
+  Please note the use of this file is deprecated and included
+  for backward compatibility. It is recommended to directly
+  include the base-specific mobile_base.launch.xml file.
+ -->
+<launch>
+  <arg name="base"/>
+  <arg name="serialport"/>
+  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
+    <arg name="serialport" value="$(arg serialport)" />
+  </include>
+</launch>


### PR DESCRIPTION
Take out the reference to the now-removed mobile_base.launch layer.