### PR TITLE
Refactor cmd_vel_mux (kinetic)

### DIFF
--- a/turtlebot_bringup/launch/concert_client.launch
+++ b/turtlebot_bringup/launch/concert_client.launch
@@ -16,7 +16,8 @@
     <arg name="stacks" value="$(arg stacks)" />
     <arg name="3d_sensor" value="$(arg 3d_sensor)" />
   </include>
-  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
+  <include file="$(find turtlebot_bringup)/launch/includes/mobile_base.launch.xml">
+    <arg name="base" value="$(arg base)" />
     <arg name="serialport" value="$(arg serialport)" />
   </include>
   <include unless="$(eval arg('battery') == 'None')" file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">

--- a/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/create/mobile_base.launch.xml
@@ -1,10 +1,9 @@
 <!--
   Create's implementation of turtlebot's mobile base.
-
-  TODO: redirect cmd_vel_mux/output to wherever create base is listening.
  -->
 <launch>
   <arg name="serialport"/>
+  <arg name="manager" default="none" /><!-- necessary parameter, but manager not actually needed for create base-->
   
   <!-- Turtlebot Driver -->
   <node pkg="create_node" type="turtlebot_node.py" name="turtlebot_node" respawn="true" args="--respawnable">
@@ -36,12 +35,5 @@
     <param name="imu_used" value="true"/>
     <param name="vo_used" value="false"/>
     <param name="output_frame" value="odom"/>
-  </node>
-
-  <!-- velocity commands multiplexer -->
-  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
-  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
-    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
-    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
   </node>
 </launch>

--- a/turtlebot_bringup/launch/includes/kobuki/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/kobuki/mobile_base.launch.xml
@@ -3,9 +3,9 @@
  -->
 <launch>
   <arg name="serialport"/> <!-- TODO: use the serialport parameter to set the serial port of kobuki -->
+  <arg name="manager"/>
   
-  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
-  <node pkg="nodelet" type="nodelet" name="mobile_base" args="load kobuki_node/KobukiNodelet mobile_base_nodelet_manager">
+  <node pkg="nodelet" type="nodelet" name="mobile_base" args="load kobuki_node/KobukiNodelet $(arg manager)">
     <rosparam file="$(find kobuki_node)/param/base.yaml" command="load"/>
     <param name="device_port" value="$(arg serialport)" />
 
@@ -16,12 +16,6 @@
     <remap from="mobile_base/enable" to="enable"/>
     <remap from="mobile_base/disable" to="disable"/>
     <remap from="mobile_base/joint_states" to="joint_states"/>
-  </node>
-
-  <!-- velocity commands multiplexer -->
-  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
-    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
-    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
   </node>
   
   <!-- bumper/cliff to pointcloud -->

--- a/turtlebot_bringup/launch/includes/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/mobile_base.launch.xml
@@ -1,0 +1,23 @@
+<!--
+  The mobile platform base.
+  
+  Selector for the base.
+ -->
+<launch>
+  <!-- mobile base nodelet manager -->
+  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
+  
+  <!-- mobile base -->
+  <arg name="base"/>
+  <arg name="serialport"/>
+  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
+    <arg name="serialport" value="$(arg serialport)"/>
+    <arg name="manager" value="mobile_base_nodelet_manager"/>
+  </include>
+  
+  <!-- velocity commands multiplexer -->
+  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
+    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
+    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
+  </node>
+</launch>

--- a/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
@@ -1,10 +1,9 @@
 <!--
   Create's implementation of turtlebot's mobile base.
-  
-  TODO: redirect cmd_vel_mux/output to wherever create base is listening.
  -->
 <launch>
   <arg name="serialport"/>
+  <arg name="manager" default="none" /><!-- necessary parameter, but manager not actually needed for roomba base-->
 
   <!-- Turtlebot Driver -->
   <node pkg="create_node" type="turtlebot_node.py" name="turtlebot_node" respawn="true" args="--respawnable">
@@ -32,12 +31,5 @@
     <param name="imu_used" value="true"/>
     <param name="vo_used" value="false"/>
     <param name="output_frame" value="odom"/>
-  </node>
-
-  <!-- velocity commands multiplexer -->
-  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
-  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
-    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
-    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
   </node>
 </launch>

--- a/turtlebot_bringup/launch/minimal.launch
+++ b/turtlebot_bringup/launch/minimal.launch
@@ -14,7 +14,8 @@
     <arg name="stacks" value="$(arg stacks)" />
     <arg name="3d_sensor" value="$(arg 3d_sensor)" />
   </include>
-  <include file="$(find turtlebot_bringup)/launch/includes/$(arg base)/mobile_base.launch.xml">
+  <include file="$(find turtlebot_bringup)/launch/includes/mobile_base.launch.xml">
+    <arg name="base" value="$(arg base)" />
     <arg name="serialport" value="$(arg serialport)" />
   </include>
   <include unless="$(eval arg('battery') == 'None')" file="$(find turtlebot_bringup)/launch/includes/netbook.launch.xml">


### PR DESCRIPTION
Moved mobile_base_nodelet_manager and cmd_vel_mux to a
common, higher-level launch file.

Currently each base-specific mobile_base.launch.xml
loaded the same cmd_vel_mux node with the same configuration.
To reduce this redundancy, launching this nodelet has been
moved to the common, higher-level mobile_base.launch.xml.

The mobile_base_nodelet_manager has been moved up to facilitate
this change.

Note: A parallel PR exists for Kinetic.