### PR TITLE
Update R200 (indigo)

### DIFF
--- a/turtlebot_bringup/launch/includes/3dsensor/r200.launch.xml
+++ b/turtlebot_bringup/launch/includes/3dsensor/r200.launch.xml
@@ -1,13 +1,15 @@
 <launch>
+<!-- "camera" should uniquely identify the device. All topics are pushed down
+       into the "camera" namespace, and it is prepended to tf frame ids. -->
   <arg name="camera"      default="camera"/>
   <arg name="publish_tf"  default="false"/>
-  <!-- Factory-calibrated depth registration -->
-  <arg name="depth_registration"              default="true"/>
+  <!-- Factory-calibrated depth registration 
+       NOTE: HW Registration not supported by R200 camera -->
+  <arg name="depth_registration"              default="false"/>
   <arg     if="$(arg depth_registration)" name="depth" value="depth_registered" />
-  <arg unless="$(arg depth_registration)" name="depth" value="depth" />
+  <arg unless="$(arg depth_registration)" name="depth" value="depth" /> 
 
-  <!-- Processing Modules -->
-  <arg name="launch_camera"                   default="true"/>                                      
+  <!-- Processing Modules -->                                    
   <arg name="rgb_processing"                  default="true"/>                                      
   <arg name="ir_processing"                   default="true"/>                                      
   <arg name="depth_processing"                default="true"/>                                      
@@ -19,19 +21,18 @@
   <!-- Worker threads for the nodelet manager -->                                                   
   <arg name="num_worker_threads" default="4" />
 
-  <!-- Start nodelet manager in provided namespace -->
-  <group ns="$(arg camera)" if="$(arg launch_camera)">
-    <arg name="manager" value="$(arg camera)_nodelet_manager" />
-    <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
-    <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
-      <arg name="name"                value="$(arg manager)" />
-      <arg name="debug"               value="$(arg debug)" />
-      <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
-    </include>
-    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-      <arg name="manager"      value="$(arg manager)" />
-      <arg name="camera"       value="$(arg camera)" />
-      <arg name="camera_type"  value="R200" />
-    </include>
-  </group>                                                                               
+  <include file="$(find realsense_camera)/launch/r200_nodelet_rgbd.launch">
+    <arg name="camera"                          value="$(arg camera)"/>                             
+    <arg name="camera_type"                     value="R200" />                                     
+    <arg name="publish_tf"                      value="$(arg publish_tf)"/>                         
+    <arg name="num_worker_threads"              value="$(arg num_worker_threads)" />                
+                                                                                                    
+    <!-- Processing Modules -->                                                                     
+    <arg name="rgb_processing"                  value="$(arg rgb_processing)"/>                     
+    <arg name="ir_processing"                   value="$(arg ir_processing)"/>                      
+    <arg name="depth_processing"                value="$(arg depth_processing)"/>                   
+    <arg name="depth_registered_processing"     value="$(arg depth_registered_processing)"/>        
+    <arg name="disparity_processing"            value="$(arg disparity_processing)"/>               
+    <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)"/>    
+  </include>                                                                                        
 </launch>

--- a/turtlebot_description/urdf/sensors/r200.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/r200.urdf.xacro
@@ -89,9 +89,9 @@
     <joint name="camera_joint" type="fixed">
       <origin xyz="${r200_cam_offset_px} ${r200_cam_offset_py} ${r200_cam_offset_pz}" rpy="0 0 0"/>
       <parent link="bracket"/>
-      <child link="camera" />
+      <child link="camera_link" />
     </joint>
-    <link name="camera">
+    <link name="camera_link">
       <visual>
        <origin xyz="0 0 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -122,7 +122,7 @@
 
     <joint name="camera_rgb_joint" type="fixed">
       <origin xyz="${r200_cam_rgb_px} ${r200_cam_rgb_py} ${r200_cam_rgb_pz}" rpy="0 0 0"/>
-      <parent link="camera"/>
+      <parent link="camera_link"/>
       <child link="camera_rgb_frame" />
     </joint>
     <link name="camera_rgb_frame"/>
@@ -133,6 +133,7 @@
       <child link="camera_rgb_optical_frame" />
     </joint>
     <link name="camera_rgb_optical_frame"/>
+
   
 
     <!--
@@ -152,6 +153,7 @@
         <child link="camera_depth_optical_frame" />
     </joint>
     <link name="camera_depth_optical_frame"/>
+
   	
   	<!-- Simulation sensor -->
     <turtlebot_sim_3dsensor/>


### PR DESCRIPTION
Two R200 cleanup changes:

1. The name of the camera link has been changed to
conform to the common standard.

2. Modified the R200 3D sensor launch file
    to conform more closely to the other
    open_ni2-style sensor launch files. This
    allows the data processing arguments passed
    in to correctly pass through and control
    image processing.
    
    This allows the turtlebot_follower package,
    for example, to set "depth_processing" to
    true to enable the /camera/depth/depth_rect/
    topic with the R200 as it can with other
    cameras.