### PR TITLE
Fix xacro warnings and remove whitespaces

### DIFF
--- a/turtlebot_bringup/launch/includes/description.launch.xml
+++ b/turtlebot_bringup/launch/includes/description.launch.xml
@@ -5,8 +5,8 @@
   <arg name="base"/>
   <arg name="stacks"/>
   <arg name="3d_sensor"/>
-  
-  <arg name="urdf_file" default="$(find xacro)/xacro.py '$(find turtlebot_description)/robots/$(arg base)_$(arg stacks)_$(arg 3d_sensor).urdf.xacro'" />
+
+  <arg name="urdf_file" default="$(find xacro)/xacro --inorder '$(find turtlebot_description)/robots/$(arg base)_$(arg stacks)_$(arg 3d_sensor).urdf.xacro'" />
   <param name="robot_description" command="$(arg urdf_file)" />
 
 </launch>

--- a/turtlebot_description/test.launch
+++ b/turtlebot_description/test.launch
@@ -1,5 +1,5 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find turtlebot_description)/robots/turtlebot.urdf.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find turtlebot_description)/robots/turtlebot.urdf.xacro'" />
   <param name="use_gui" value="True"/>
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" ></node>
   <node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher" output="screen">

--- a/turtlebot_description/test/test_urdf.cpp
+++ b/turtlebot_description/test/test_urdf.cpp
@@ -37,13 +37,13 @@
 #include <gtest/gtest.h>
 #include <cstdlib>
 
-#include <dirent.h> 
-#include <sys/types.h> 
-#include <sys/param.h> 
-#include <sys/stat.h> 
-#include <unistd.h> 
-#include <stdio.h> 
-#include <string.h> 
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <iostream>
 
@@ -63,7 +63,7 @@ int walker( char *result, int& test_result)
   }
   while( ( dir = readdir( d ) ) )
   {
-    if( strcmp( dir->d_name, "." ) == 0 || 
+    if( strcmp( dir->d_name, "." ) == 0 ||
         strcmp( dir->d_name, ".." ) == 0 )
     {
       continue;
@@ -76,7 +76,7 @@ int walker( char *result, int& test_result)
         char pwd[MAXPATHLEN];
         getcwd( pwd, MAXPATHLEN );
         printf("\n\ntesting: %s\n",(std::string(pwd)+"/robots/"+dir_name).c_str());
-        runExternalProcess("python `rospack find xacro`/xacro.py", std::string(pwd)+"/robots/"+dir_name+" > `rospack find turtlebot_description`/test/tmp.urdf" );
+        runExternalProcess("python `rospack find xacro`/xacro --inorder", std::string(pwd)+"/robots/"+dir_name+" > `rospack find turtlebot_description`/test/tmp.urdf" );
         test_result = test_result || runExternalProcess("`rospack find urdf_parser`/bin/check_urdf", "`rospack find turtlebot_description`/test/tmp.urdf");
         //break;
       }


### PR DESCRIPTION
PR fixes the issue: #252 

* Changed all **xacro.py** calls to **xacro --inorder**, as described in [here](http://wiki.ros.org/xacro#Processing_Order).
* Removed some whitespaces.