### PR TITLE
remove up_axis tag from DAE meshes

### DIFF
--- a/turtlebot_description/meshes/sensors/kinect.dae
+++ b/turtlebot_description/meshes/sensors/kinect.dae
@@ -9,7 +9,6 @@
     <created>2013-03-07T11:38:26</created>
     <modified>2013-03-07T11:38:26</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/sensors/r200.dae
+++ b/turtlebot_description/meshes/sensors/r200.dae
@@ -7,7 +7,6 @@
         <created>2015-05-31T08:41:34Z</created>
         <modified>2015-05-31T08:41:34Z</modified>
         <unit meter="0.002539999969303608" name="inch" /><!-- Changed! -->
-        <up_axis>Z_UP</up_axis>
     </asset>
     <library_visual_scenes>
         <visual_scene id="ID1">

--- a/turtlebot_description/meshes/sensors/sensor_pole.dae
+++ b/turtlebot_description/meshes/sensors/sensor_pole.dae
@@ -9,7 +9,6 @@
     <created>2015-03-16T14:24:59</created>
     <modified>2015-03-16T14:24:59</modified>
     <unit name="millimeter" meter="0.001"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/sensors/xtion_pro_camera.dae
+++ b/turtlebot_description/meshes/sensors/xtion_pro_camera.dae
@@ -8,7 +8,6 @@
     <created>2015-02-26T12:05:50</created>
     <modified>2015-02-26T12:05:50</modified>
     <unit name="millimeter" meter="0.001"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/sensors/xtion_pro_stack.dae
+++ b/turtlebot_description/meshes/sensors/xtion_pro_stack.dae
@@ -9,7 +9,6 @@
     <created>2015-03-16T14:25:40</created>
     <modified>2015-03-16T14:25:40</modified>
     <unit name="millimeter" meter="0.001"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/circles/plate_0_logo.dae
+++ b/turtlebot_description/meshes/stacks/circles/plate_0_logo.dae
@@ -11,7 +11,6 @@
 		<created>2011-03-08T12:41:12.567344</created>
 		<modified>2011-03-08T12:41:12.567357</modified>
 		<unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="plate_0_tga-fx" name="plate_0_tga-fx">

--- a/turtlebot_description/meshes/stacks/circles/plate_1_logo.dae
+++ b/turtlebot_description/meshes/stacks/circles/plate_1_logo.dae
@@ -11,7 +11,6 @@
 		<created>2011-03-08T12:40:21.485977</created>
 		<modified>2011-03-08T12:40:21.485998</modified>
     <unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="plate_1_tga-fx" name="plate_1_tga-fx">

--- a/turtlebot_description/meshes/stacks/circles/plate_2_logo.dae
+++ b/turtlebot_description/meshes/stacks/circles/plate_2_logo.dae
@@ -11,7 +11,6 @@
 		<created>2011-03-08T12:41:39.033566</created>
 		<modified>2011-03-08T12:41:39.033583</modified>
     <unit meter="1.0" name="meter"/>
-		<up_axis>Z_UP</up_axis>
 	</asset>
 	<library_effects>
 		<effect id="plate_2_tga-fx" name="plate_2_tga-fx">

--- a/turtlebot_description/meshes/stacks/hexagons/plate_bottom.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/plate_bottom.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:25:28</created>
     <modified>2013-02-26T15:25:28</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/plate_middle.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/plate_middle.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:26:38</created>
     <modified>2013-02-26T15:26:38</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/plate_top.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/plate_top.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:27:15</created>
     <modified>2013-02-26T15:27:15</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/pole_bottom.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/pole_bottom.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:22:10</created>
     <modified>2013-02-26T15:22:10</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/pole_kinect.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/pole_kinect.dae
@@ -9,7 +9,6 @@
     <created>2013-03-08T09:58:31</created>
     <modified>2013-03-08T09:58:31</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/pole_middle.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/pole_middle.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:22:55</created>
     <modified>2013-02-26T15:22:55</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/turtlebot_description/meshes/stacks/hexagons/pole_top.dae
+++ b/turtlebot_description/meshes/stacks/hexagons/pole_top.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T15:23:31</created>
     <modified>2013-02-26T15:23:31</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">


### PR DESCRIPTION
RViz doesn't respect it anyway ( https://github.com/ros-visualization/rviz/issues/1045 ), but current versions of three.js' ColladaLoader (used in the RobotWebTools, see https://github.com/RobotWebTools/ros3djs/pull/202 ) do!

(Since RViz doesn't respect the tag, this does not break the model)