### PR TITLE
[.rosinstall] Invalid branch name.

### DIFF
--- a/turtlebot.rosinstall
+++ b/turtlebot.rosinstall
@@ -19,7 +19,7 @@
 - git:
     uri: https://github.com/yujinrobot/yocs_msgs.git
     local-name: yocs_msgs
-    version: indigo
+    version: devel
 
 - git:
     uri: https://github.com/yujinrobot/yujin_ocs.git


### PR DESCRIPTION
As of 20181201 I don't see [`indigo` branch on `yocs_msgs` repo](https://github.com/yujinrobot/yocs_msgs/branches/all?utf8=%E2%9C%93&query=indigo).