### PR TITLE
Fix turtlebot_description dependencies and unit test

### DIFF
--- a/turtlebot_description/CMakeLists.txt
+++ b/turtlebot_description/CMakeLists.txt
@@ -19,8 +19,8 @@ install(DIRECTORY urdf
 )
 
 if(CATKIN_ENABLE_TESTING)
-
-	catkin_add_gtest(${PROJECT_NAME}_test_urdf test/test_urdf.cpp)
+	catkin_add_gtest(${PROJECT_NAME}_test_urdf test/test_urdf.cpp
+	                 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
 endif()
 

--- a/turtlebot_description/CMakeLists.txt
+++ b/turtlebot_description/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 project(turtlebot_description)
-find_package(catkin REQUIRED COMPONENTS urdf xacro)
+find_package(catkin REQUIRED)
 
-catkin_package(
-   CATKIN_DEPENDS urdf xacro
-)
+catkin_package()
 
 install(DIRECTORY robots
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/turtlebot_description/package.xml
+++ b/turtlebot_description/package.xml
@@ -14,10 +14,6 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>urdf</build_depend>
-  <build_depend>xacro</build_depend>
-
-  <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>kobuki_description</run_depend>
   <run_depend>create_description</run_depend>

--- a/turtlebot_description/package.xml
+++ b/turtlebot_description/package.xml
@@ -17,4 +17,7 @@
   <run_depend>xacro</run_depend>
   <run_depend>kobuki_description</run_depend>
   <run_depend>create_description</run_depend>
+
+  <test_depend>liburdfdom-tools</test_depend>
+
 </package>

--- a/turtlebot_description/test/test_urdf.cpp
+++ b/turtlebot_description/test/test_urdf.cpp
@@ -52,15 +52,12 @@ int runExternalProcess(const std::string &executable, const std::string &args)
     return system((executable + " " + args).c_str());
 }
 
-int walker( char *result, int& test_result)
+TEST(URDF, CorrectFormat)
 {
   DIR           *d;
   struct dirent *dir;
   d = opendir( "robots" );
-  if( d == NULL )
-  {
-    return 1;
-  }
+  ASSERT_TRUE(d != NULL);
   while( ( dir = readdir( d ) ) )
   {
     if( strcmp( dir->d_name, "." ) == 0 ||
@@ -76,31 +73,13 @@ int walker( char *result, int& test_result)
         char pwd[MAXPATHLEN];
         getcwd( pwd, MAXPATHLEN );
         printf("\n\ntesting: %s\n",(std::string(pwd)+"/robots/"+dir_name).c_str());
-        runExternalProcess("python `rospack find xacro`/xacro --inorder", std::string(pwd)+"/robots/"+dir_name+" > `rospack find turtlebot_description`/test/tmp.urdf");
-        test_result = test_result || runExternalProcess("`rospack find urdf_parser`/bin/check_urdf", "`rospack find turtlebot_description`/test/tmp.urdf");
+        EXPECT_EQ(0, runExternalProcess("xacro --inorder", std::string(pwd)+"/robots/"+dir_name+" > test/tmp.urdf"));
+        EXPECT_EQ(0, runExternalProcess("check_urdf", "test/tmp.urdf"));
         //break;
       }
     }
   }
   closedir( d );
-  return *result == 0;
-}
-
-TEST(URDF, CorrectFormat)
-{
-  int test_result = 0;
-
-  char buf[MAXPATHLEN] = { 0 };
-  if( walker( buf, test_result ) == 0 )
-  {
-    printf( "Found: %s\n", buf );
-  }
-  else
-  {
-    puts( "Not found" );
-  }
-
-  EXPECT_TRUE(test_result == 0);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
`xacro` and `urdf` are not required for building the package as it only provides urdf files and models.
`urdf` is not even a run-time dependency and provides a library only.

The unit test was probably not updated since ROS groovy and package [urdf_parser](http://wiki.ros.org/urdf_parser) is deprecated. The second commit updates the unit test and makes it compatible to ROS kinetic and above.