### PR TITLE
Melodic dev

### DIFF
--- a/setup_create.sh
+++ b/setup_create.sh
@@ -4,7 +4,7 @@
 #
 # You may wish to set the 3d sensor to asus_xtion_pro if you do not have a kinect
 # though. While the kinect settings work for the asus in terms of 3d sensing (openni
-# handles the abstraction) the asus settiing makes sure the mesh shown in rviz/gazebo 
+# handles the abstraction) the asus setting makes sure the mesh shown in rviz/gazebo 
 # is the asus.
 
 export TURTLEBOT_BASE=create

--- a/setup_create2.sh
+++ b/setup_create2.sh
@@ -1,0 +1,16 @@
+# This configures the environment variables for a create based turtlebot
+# running the Turtlebot 2.0 software. This is necessary to run after
+# setup.bash to ensure the create drivers and nodes are all correctly launched.
+# Note that Create  and Create 2 have different baud rates. Create 2 is based on
+# a Roomba 600 series, thus we use TURTLEBOT_BASE=roomba for Create 2 to avoid
+# baudrate sci cable connection errors.
+#
+# You may wish to set the 3d sensor to asus_xtion_pro if you do not have a kinect
+# though. While the kinect settings work for the asus in terms of 3d sensing (openni
+# handles the abstraction) the asus settiing makes sure the mesh shown in rviz/gazebo 
+# is the asus.
+
+export TURTLEBOT_BASE=roomba
+export TURTLEBOT_STACKS=circles
+export TURTLEBOT_3D_SENSOR=kinect
+export TURTLEBOT_SIMULATION=false

--- a/setup_create2.sh
+++ b/setup_create2.sh
@@ -7,7 +7,7 @@
 #
 # You may wish to set the 3d sensor to asus_xtion_pro if you do not have a kinect
 # though. While the kinect settings work for the asus in terms of 3d sensing (openni
-# handles the abstraction) the asus settiing makes sure the mesh shown in rviz/gazebo 
+# handles the abstraction) the asus setting makes sure the mesh shown in rviz/gazebo 
 # is the asus.
 
 export TURTLEBOT_BASE=roomba

--- a/setup_kobuki.sh
+++ b/setup_kobuki.sh
@@ -4,7 +4,7 @@
 #
 # You may wish to set the 3d sensor to asus_xtion_pro if you do not have a kinect
 # though. While the kinect settings work for the asus in terms of 3d sensing (openni
-# handles the abstraction) the asus settiing makes sure the mesh shown in rviz/gazebo 
+# handles the abstraction) the asus setting makes sure the mesh shown in rviz/gazebo 
 # is the asus.
 
 export TURTLEBOT_BASE=kobuki

--- a/turtlebot_bringup/launch/3dsensor.launch
+++ b/turtlebot_bringup/launch/3dsensor.launch
@@ -63,7 +63,7 @@
       <!-- Pixel rows to use to generate the laserscan. For each column, the scan will
            return the minimum value for those pixels centered vertically in the image. -->
       <param name="scan_height" value="10"/>
-      <param name="output_frame_id" value="/$(arg camera)_depth_frame"/>
+      <param name="output_frame_id" value="$(arg camera)_depth_frame"/>
       <param name="range_min" value="0.45"/>
       <remap from="image" to="$(arg camera)/$(arg depth)/image_raw"/>
       <remap from="scan" to="$(arg scan_topic)"/>

--- a/turtlebot_bringup/launch/includes/3dsensor/kinect.launch.xml
+++ b/turtlebot_bringup/launch/includes/3dsensor/kinect.launch.xml
@@ -20,18 +20,18 @@
   <!-- Worker threads for the nodelet manager -->
   <arg name="num_worker_threads" default="4" />
 
-  <include file="$(find openni_launch)/launch/openni.launch">
-    <arg name="camera"                          value="$(arg camera)"/>
-    <arg name="publish_tf"                      value="$(arg publish_tf)"/>
-    <arg name="depth_registration"              value="$(arg depth_registration)"/>
-    <arg name="num_worker_threads"              value="$(arg num_worker_threads)" />
+  <include file="$(find freenect_launch)/launch/freenect.launch">
+    <arg name="camera"                          value="$(arg camera)"/>                             
+    <arg name="publish_tf"                      value="$(arg publish_tf)"/>                         
+    <arg name="depth_registration"              value="$(arg depth_registration)"/>                 
+    <arg name="num_worker_threads"              value="$(arg num_worker_threads)" />                
 
-    <!-- Processing Modules -->
-    <arg name="rgb_processing"                  value="$(arg rgb_processing)"/>
-    <arg name="ir_processing"                   value="$(arg ir_processing)"/>
-    <arg name="depth_processing"                value="$(arg depth_processing)"/>
-    <arg name="depth_registered_processing"     value="$(arg depth_registered_processing)"/>
-    <arg name="disparity_processing"            value="$(arg disparity_processing)"/>
-    <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)"/>
-  </include>
+    <!-- Processing Modules -->                                                                     
+    <arg name="rgb_processing"                  value="$(arg rgb_processing)"/>                     
+    <arg name="ir_processing"                   value="$(arg ir_processing)"/>                      
+    <arg name="depth_processing"                value="$(arg depth_processing)"/>                   
+    <arg name="depth_registered_processing"     value="$(arg depth_registered_processing)"/>        
+    <arg name="disparity_processing"            value="$(arg disparity_processing)"/>               
+    <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)"/>    
+  </include>  
 </launch>

--- a/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
+++ b/turtlebot_bringup/launch/includes/roomba/mobile_base.launch.xml
@@ -17,9 +17,14 @@
     <remap from="imu/data" to="mobile_base/sensors/imu_data" />
     <remap from="imu/raw" to="mobile_base/sensors/imu_data_raw" />
   </node>
-  
+
   <!-- Enable breaker 1 for the kinect -->
-  <!--node pkg="create_node" type="kinect_breaker_enabler.py" name="kinect_breaker_enabler"/-->
+  <node pkg="create_node" type="kinect_breaker_enabler.py" name="kinect_breaker_enabler"/>
+
+  <!-- Load create and gyro calibration  -->
+  <node pkg="create_node" type="load_calib.py" name="create_load_calibration">
+    <remap from="cmd_vel" to="mobile_base/commands/velocity" />
+  </node>
   
   <!-- The odometry estimator -->
   <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">

--- a/turtlebot_bringup/package.xml
+++ b/turtlebot_bringup/package.xml
@@ -27,7 +27,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>robot_pose_ekf</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
-  <run_depend>openni_launch</run_depend>
+  <run_depend>freenect_launch</run_depend>
   <run_depend>laptop_battery_monitor</run_depend>
   <run_depend>rocon_app_manager</run_depend>
   <run_depend>rocon_bubble_icons</run_depend>


### PR DESCRIPTION
Added a setup .sh file for create 2. Many people use the "create" thinking the "Create 1" and "Create 2" are the same, but they use different baud rates. setup_create2.sh will use the "roomba" robot type which is the correct baud rate, as the create 2 is based on the roomba 600 series.

Also fixed a few spelling errors.