### PR TITLE
Add xacro xml namespace prefix to macro usages

### DIFF
--- a/turtlebot_description/robots/create_circles_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/create_circles_asus_xtion_pro.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
 
-  <create/>
-  <stack_circles parent="base_link"/>
-  <sensor_asus_xtion_pro  parent="base_link"/>
+  <xacro:create/>
+  <xacro:stack_circles parent="base_link"/>
+  <xacro:sensor_asus_xtion_pro  parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/create_circles_kinect.urdf.xacro
+++ b/turtlebot_description/robots/create_circles_kinect.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
 
-  <create/>
-  <stack_circles parent="base_link"/>
-  <sensor_kinect  parent="base_link"/>
+  <xacro:create/>
+  <xacro:stack_circles parent="base_link"/>
+  <xacro:sensor_kinect  parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/kobuki_hexagons_astra.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_astra.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/astra.urdf.xacro"/>
   
-  <kobuki/>
-  <stack_hexagons parent="base_link"/>
-  <sensor_astra parent="base_link"/>
+  <xacro:kobuki/>
+  <xacro:stack_hexagons parent="base_link"/>
+  <xacro:sensor_astra parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
   
-  <kobuki/>
-  <stack_hexagons                 parent="base_link"/>
-  <sensor_asus_xtion_pro          parent="base_link"/>
+  <xacro:kobuki/>
+  <xacro:stack_hexagons                 parent="base_link"/>
+  <xacro:sensor_asus_xtion_pro          parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro_offset.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_asus_xtion_pro_offset.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro_offset.urdf.xacro"/>
   
-  <kobuki/>
-  <stack_hexagons                 parent="base_link"/>
-  <sensor_asus_xtion_pro_offset   parent="base_link"/>
+  <xacro:kobuki/>
+  <xacro:stack_hexagons                 parent="base_link"/>
+  <xacro:sensor_asus_xtion_pro_offset   parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_kinect.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
   
-  <kobuki/>
-  <stack_hexagons parent="base_link"/>
-  <sensor_kinect  parent="base_link"/>
+  <xacro:kobuki/>
+  <xacro:stack_hexagons parent="base_link"/>
+  <xacro:sensor_kinect  parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/kobuki_hexagons_r200.urdf.xacro
+++ b/turtlebot_description/robots/kobuki_hexagons_r200.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/r200.urdf.xacro"/>
   
-  <kobuki/>
-  <stack_hexagons parent="base_link"/>
-  <sensor_r200  parent="base_link"/>
+  <xacro:kobuki/>
+  <xacro:stack_hexagons parent="base_link"/>
+  <xacro:sensor_r200  parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_asus_xtion_pro.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
 
-  <create/>
-  <stack_circles parent="base_link"/>
-  <sensor_asus_xtion_pro  parent="base_link"/>
+  <xacro:create/>
+  <xacro:stack_circles parent="base_link"/>
+  <xacro:sensor_asus_xtion_pro  parent="base_link"/>
 </robot>

--- a/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
+++ b/turtlebot_description/robots/roomba_circles_kinect.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/stacks/circles.urdf.xacro"/>
   <xacro:include filename="$(find turtlebot_description)/urdf/sensors/kinect.urdf.xacro"/>
 
-  <create/>
-  <stack_circles parent="base_link"/>
-  <sensor_kinect  parent="base_link"/>
+  <xacro:create/>
+  <xacro:stack_circles parent="base_link"/>
+  <xacro:sensor_kinect  parent="base_link"/>
 </robot>

--- a/turtlebot_description/urdf/sensors/astra.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/astra.urdf.xacro
@@ -68,7 +68,7 @@
     <link name="camera_depth_optical_frame"/>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
-    <turtlebot_sim_3dsensor/>
+    <xacro:turtlebot_sim_3dsensor/>
 
   </xacro:macro>
 </robot>

--- a/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
@@ -69,7 +69,7 @@
     <link name="camera_depth_optical_frame"/>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
-    <turtlebot_sim_3dsensor/>
+    <xacro:turtlebot_sim_3dsensor/>
 
 
     <!-- Asus mount -->

--- a/turtlebot_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
@@ -69,6 +69,6 @@
     <link name="camera_depth_optical_frame"/>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
-    <turtlebot_sim_3dsensor/>
+    <xacro:turtlebot_sim_3dsensor/>
   </xacro:macro>
 </robot>

--- a/turtlebot_description/urdf/sensors/kinect.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/kinect.urdf.xacro
@@ -65,6 +65,6 @@
 	<link name="camera_depth_optical_frame"/>
 	
 	<!-- Kinect sensor for simulation -->
-	<turtlebot_sim_3dsensor/>
+	<xacro:turtlebot_sim_3dsensor/>
   </xacro:macro>
 </robot>

--- a/turtlebot_description/urdf/sensors/r200.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/r200.urdf.xacro
@@ -156,6 +156,6 @@
     
   	
   	<!-- Simulation sensor -->
-    <turtlebot_sim_3dsensor/>
+    <xacro:turtlebot_sim_3dsensor/>
   </xacro:macro>
 </robot>

--- a/turtlebot_description/urdf/stacks/circles.urdf.xacro
+++ b/turtlebot_description/urdf/stacks/circles.urdf.xacro
@@ -163,10 +163,10 @@
   </xacro:macro>
 
   <xacro:macro name="stack_circles" params="parent">
-    <turtlebot_spacer parent="${parent}" number="0" x_loc="-0.00254" y_loc="0.1114679" z_loc="0.062992"/>
-    <turtlebot_spacer parent="${parent}" number="1" x_loc="-0.00254" y_loc="-0.1114679" z_loc="0.062992"/>
-    <turtlebot_spacer parent="${parent}" number="2" x_loc="-0.07239" y_loc="-0.1114679" z_loc="0.062992"/>
-    <turtlebot_spacer parent="${parent}" number="3" x_loc="-0.07239" y_loc="0.1114679" z_loc="0.062992"/>
+    <xacro:turtlebot_spacer parent="${parent}" number="0" x_loc="-0.00254" y_loc="0.1114679" z_loc="0.062992"/>
+    <xacro:turtlebot_spacer parent="${parent}" number="1" x_loc="-0.00254" y_loc="-0.1114679" z_loc="0.062992"/>
+    <xacro:turtlebot_spacer parent="${parent}" number="2" x_loc="-0.07239" y_loc="-0.1114679" z_loc="0.062992"/>
+    <xacro:turtlebot_spacer parent="${parent}" number="3" x_loc="-0.07239" y_loc="0.1114679" z_loc="0.062992"/>
 
     <joint name="plate_0_joint" type="fixed">
       <origin xyz="-0.04334 0  0.06775704" rpy="0 0 0" />
@@ -199,10 +199,10 @@
       </collision>
     </link>
 
-    <turtlebot_standoff_2in parent="${parent}" number="0" x_loc="0.0676402" y_loc="0.1314196" z_loc="0.0709803"/>
-    <turtlebot_standoff_2in parent="${parent}" number="1" x_loc="0.0676402" y_loc="-0.1314196" z_loc="0.0709803"/>
-    <turtlebot_standoff_2in parent="${parent}" number="2" x_loc="-0.052832" y_loc="-0.1314196" z_loc="0.0709803"/>
-    <turtlebot_standoff_2in parent="${parent}" number="3" x_loc="-0.052832" y_loc="0.1314196" z_loc="0.0709803"/>
+    <xacro:turtlebot_standoff_2in parent="${parent}" number="0" x_loc="0.0676402" y_loc="0.1314196" z_loc="0.0709803"/>
+    <xacro:turtlebot_standoff_2in parent="${parent}" number="1" x_loc="0.0676402" y_loc="-0.1314196" z_loc="0.0709803"/>
+    <xacro:turtlebot_standoff_2in parent="${parent}" number="2" x_loc="-0.052832" y_loc="-0.1314196" z_loc="0.0709803"/>
+    <xacro:turtlebot_standoff_2in parent="${parent}" number="3" x_loc="-0.052832" y_loc="0.1314196" z_loc="0.0709803"/>
 
     <joint name="plate_1_joint" type="fixed">
       <origin xyz="0.04068 0 0.05715" rpy="0 0 0" />
@@ -234,10 +234,10 @@
       </collision>
     </link>
 
-    <turtlebot_standoff_2in parent="standoff_2in_0_link" number="4" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_2in parent="standoff_2in_1_link" number="5" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_2in parent="standoff_2in_2_link" number="6" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_2in parent="standoff_2in_3_link" number="7" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_2in parent="standoff_2in_0_link" number="4" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_2in parent="standoff_2in_1_link" number="5" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_2in parent="standoff_2in_2_link" number="6" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_2in parent="standoff_2in_3_link" number="7" x_loc="0" y_loc="0" z_loc="0.05715"/>
 
     <joint name="plate_2_joint" type="fixed">
       <origin xyz="0 0 0.0572008" rpy="0 0 0" />
@@ -269,13 +269,13 @@
       </collision>
     </link>
 
-    <turtlebot_standoff_kinect parent="plate_2_link" number="0" x_loc="-0.1024382" y_loc="0.098" z_loc="0.0032004"/>
-    <turtlebot_standoff_kinect parent="plate_2_link" number="1" x_loc="-0.1024382" y_loc="-0.098" z_loc="0.0032004"/>
+    <xacro:turtlebot_standoff_kinect parent="plate_2_link" number="0" x_loc="-0.1024382" y_loc="0.098" z_loc="0.0032004"/>
+    <xacro:turtlebot_standoff_kinect parent="plate_2_link" number="1" x_loc="-0.1024382" y_loc="-0.098" z_loc="0.0032004"/>
 
-    <turtlebot_standoff_8in parent="standoff_2in_4_link" number="0" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_8in parent="standoff_2in_5_link" number="1" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_8in parent="standoff_2in_6_link" number="2" x_loc="0" y_loc="0" z_loc="0.05715"/>
-    <turtlebot_standoff_8in parent="standoff_2in_7_link" number="3" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_8in parent="standoff_2in_4_link" number="0" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_8in parent="standoff_2in_5_link" number="1" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_8in parent="standoff_2in_6_link" number="2" x_loc="0" y_loc="0" z_loc="0.05715"/>
+    <xacro:turtlebot_standoff_8in parent="standoff_2in_7_link" number="3" x_loc="0" y_loc="0" z_loc="0.05715"/>
 
     <joint name="plate_3_joint" type="fixed">
       <origin xyz="-0.01316 0 0.2063496" rpy="0 0 0" />

--- a/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
+++ b/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
@@ -132,12 +132,12 @@
     other, but there is no necessary reason to do so.
   -->
   <xacro:macro name="stack_hexagons" params="parent">
-    <stack_bottom_pole parent="${parent}" number="0" x_loc= "0.120" y_loc= "0.082" z_loc="0.1028"/>
-    <stack_bottom_pole parent="${parent}" number="1" x_loc= "0.055" y_loc= "0.120" z_loc="0.1028"/>
-    <stack_bottom_pole parent="${parent}" number="2" x_loc="-0.055" y_loc= "0.120" z_loc="0.1028"/>
-    <stack_bottom_pole parent="${parent}" number="3" x_loc= "0.120" y_loc="-0.082" z_loc="0.1028"/>
-    <stack_bottom_pole parent="${parent}" number="4" x_loc= "0.055" y_loc="-0.120" z_loc="0.1028"/>
-    <stack_bottom_pole parent="${parent}" number="5" x_loc="-0.055" y_loc="-0.120" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="0" x_loc= "0.120" y_loc= "0.082" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="1" x_loc= "0.055" y_loc= "0.120" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="2" x_loc="-0.055" y_loc= "0.120" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="3" x_loc= "0.120" y_loc="-0.082" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="4" x_loc= "0.055" y_loc="-0.120" z_loc="0.1028"/>
+    <xacro:stack_bottom_pole parent="${parent}" number="5" x_loc="-0.055" y_loc="-0.120" z_loc="0.1028"/>
     
     <joint name="plate_bottom_joint" type="fixed">
       <origin xyz="0.02364 0.0 0.1306" rpy="0 0 0"/>
@@ -166,10 +166,10 @@
       </inertial>
     </link>
     
-    <stack_middle_pole parent="${parent}" number="0" x_loc= "0.0381" y_loc= "0.1505" z_loc="0.1640"/>
-    <stack_middle_pole parent="${parent}" number="1" x_loc= "0.0381" y_loc="-0.1505" z_loc="0.1640"/>
-    <stack_middle_pole parent="${parent}" number="2" x_loc="-0.0381" y_loc= "0.1505" z_loc="0.1640"/>
-    <stack_middle_pole parent="${parent}" number="3" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1640"/>
+    <xacro:stack_middle_pole parent="${parent}" number="0" x_loc= "0.0381" y_loc= "0.1505" z_loc="0.1640"/>
+    <xacro:stack_middle_pole parent="${parent}" number="1" x_loc= "0.0381" y_loc="-0.1505" z_loc="0.1640"/>
+    <xacro:stack_middle_pole parent="${parent}" number="2" x_loc="-0.0381" y_loc= "0.1505" z_loc="0.1640"/>
+    <xacro:stack_middle_pole parent="${parent}" number="3" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1640"/>
     
     <joint name="plate_middle_joint" type="fixed">
       <origin xyz="-0.01364 0.0 0.1874" rpy="0 0 0"/>
@@ -198,12 +198,12 @@
       </inertial>  
     </link>
     
-    <stack_top_pole parent="${parent}" number="0" x_loc= "0.0381" y_loc= "0.1505" z_loc="0.2920"/>
-    <stack_top_pole parent="${parent}" number="1" x_loc= "0.0381" y_loc="-0.1505" z_loc="0.2920"/>
-    <stack_top_pole parent="${parent}" number="2" x_loc="-0.0381" y_loc= "0.1505" z_loc="0.2920"/>
-    <stack_top_pole parent="${parent}" number="3" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.2920"/>
-    <stack_3d_sensor_pole parent="${parent}" number="0" x_loc="-0.1024" y_loc= "0.098" z_loc="0.2372"/>
-    <stack_3d_sensor_pole parent="${parent}" number="1" x_loc="-0.1024" y_loc="-0.098" z_loc="0.2372"/>
+    <xacro:stack_top_pole parent="${parent}" number="0" x_loc= "0.0381" y_loc= "0.1505" z_loc="0.2920"/>
+    <xacro:stack_top_pole parent="${parent}" number="1" x_loc= "0.0381" y_loc="-0.1505" z_loc="0.2920"/>
+    <xacro:stack_top_pole parent="${parent}" number="2" x_loc="-0.0381" y_loc= "0.1505" z_loc="0.2920"/>
+    <xacro:stack_top_pole parent="${parent}" number="3" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.2920"/>
+    <xacro:stack_3d_sensor_pole parent="${parent}" number="0" x_loc="-0.1024" y_loc= "0.098" z_loc="0.2372"/>
+    <xacro:stack_3d_sensor_pole parent="${parent}" number="1" x_loc="-0.1024" y_loc="-0.098" z_loc="0.2372"/>
     
     <joint name="plate_top_joint" type="fixed">
       <origin xyz="-0.01364 0.0  0.3966" rpy="0 0 0"/>


### PR DESCRIPTION
Deprecated: xacro tag 'kobuki' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)
