### PR TITLE
Fix xtion visual

### DIFF
--- a/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/asus_xtion_pro.urdf.xacro
@@ -4,7 +4,6 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_properties.urdf.xacro"/>
   
   <!-- Xacro properties -->
-  <xacro:property name="M_SCALE" value="0.001"/>
   <xacro:property name="asus_xtion_pro_cam_py" value="0.0205"/>
   <xacro:property name="asus_xtion_pro_depth_rel_rgb_py" value="0.0270" />
   <xacro:property name="asus_xtion_pro_cam_rel_rgb_py"   value="-0.0220" />
@@ -36,7 +35,7 @@
       <visual>
         <origin xyz="-0.015 0.0035 0.004" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://turtlebot_description/meshes/sensors/xtion_pro_camera.dae" scale="${M_SCALE} ${M_SCALE} ${M_SCALE}"/>
+          <mesh filename="package://turtlebot_description/meshes/sensors/xtion_pro_camera.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/turtlebot_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
+++ b/turtlebot_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
@@ -4,7 +4,6 @@
   <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_properties.urdf.xacro"/>
   
   <!-- Xacro properties -->
-  <xacro:property name="M_SCALE" value="0.001"/>
   <xacro:property name="asus_xtion_pro_offset_cam_py" value="-0.0125"/>
   <xacro:property name="asus_xtion_pro_offset_depth_rel_rgb_py" value="0.0270" />
   <xacro:property name="asus_xtion_pro_offset_cam_rel_rgb_py"   value="-0.0220" />
@@ -34,9 +33,9 @@
     </joint>
     <link name="camera_link">
       <visual>
-        <origin xyz="-0.01 0 0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
+        <origin xyz="-0.015 0.0035 0.004" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://turtlebot_description/meshes/sensors/asus_xtion_pro_live.dae" scale="${M_SCALE} ${M_SCALE} ${M_SCALE}"/>
+          <mesh filename="package://turtlebot_description/meshes/sensors/xtion_pro_camera.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -70,5 +69,34 @@
 
     <!-- RGBD sensor for simulation, same as Kinect -->
     <xacro:turtlebot_sim_3dsensor/>
+
+
+    <!-- Asus mount -->
+    <joint name="mount_asus_xtion_pro_joint" type="fixed">
+      <origin xyz="-0.1024 0.0 0.272" rpy="0 0 0"/>
+      <parent link="${parent}"/>
+      <child link="mount_asus_xtion_pro_link"/>
+    </joint>
+    <link name="mount_asus_xtion_pro_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
+        <geometry>
+          <mesh filename="package://turtlebot_description/meshes/sensors/xtion_pro_stack.dae"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <geometry>
+        <box size="0.0330 0.2760 0.0120"/>
+      </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.170" />
+        <origin xyz="0 0 0" />
+        <inertia ixx="0.001152600" ixy="0.0" ixz="0.0"
+                 iyy="0.000148934" iyz="0.0"
+                 izz="0.001154654" />
+      </inertial>
+    </link>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
On default position, revert mesh scaling (now you cannot see the camera cause it appears microscopiic)
On offset camera, use same mesh (cooler) and add missing mount