### PR TITLE
Replace the cylinder collision model of top and middle plates with a simplified mesh

### DIFF
--- a/turtlebot_description/meshes/stacks/hexagons/plate_simple.stl
+++ b/turtlebot_description/meshes/stacks/hexagons/plate_simple.stl
@@ -1,0 +1,198 @@
+solid OpenSCAD_Model
+  facet normal 0 0 -1
+    outer loop
+      vertex 130 105 -3
+      vertex -20 170 -3
+      vertex 20 170 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 130 -105 -3
+      vertex -20 -170 -3
+      vertex -20 170 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 130 -105 -3
+      vertex -20 170 -3
+      vertex 130 105 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20 -170 -3
+      vertex -157 -90 -3
+      vertex -157 90 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -20 170 -3
+      vertex -20 -170 -3
+      vertex -157 90 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 130 -105 -3
+      vertex 20 -170 -3
+      vertex -20 -170 -3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20 170 3
+      vertex -20 170 3
+      vertex 130 105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20 170 3
+      vertex -20 -170 3
+      vertex 130 -105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 130 105 3
+      vertex -20 170 3
+      vertex 130 -105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -157 90 3
+      vertex -157 -90 3
+      vertex -20 -170 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -157 90 3
+      vertex -20 -170 3
+      vertex -20 170 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20 -170 3
+      vertex 20 -170 3
+      vertex 130 -105 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 130 105 -3
+      vertex 130 -105 3
+      vertex 130 -105 -3
+    endloop
+  endfacet
+  facet normal 1 0 -0
+    outer loop
+      vertex 130 105 -3
+      vertex 130 105 3
+      vertex 130 -105 3
+    endloop
+  endfacet
+  facet normal 0.508729 0.860927 0
+    outer loop
+      vertex 20 170 -3
+      vertex 130 105 3
+      vertex 130 105 -3
+    endloop
+  endfacet
+  facet normal 0.508729 0.860927 -0
+    outer loop
+      vertex 20 170 -3
+      vertex 20 170 3
+      vertex 130 105 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -20 170 -3
+      vertex 20 170 3
+      vertex 20 170 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -20 170 -3
+      vertex -20 170 3
+      vertex 20 170 3
+    endloop
+  endfacet
+  facet normal -0.504263 0.86355 0
+    outer loop
+      vertex -157 90 -3
+      vertex -20 170 3
+      vertex -20 170 -3
+    endloop
+  endfacet
+  facet normal -0.504263 0.86355 0
+    outer loop
+      vertex -157 90 -3
+      vertex -157 90 3
+      vertex -20 170 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -157 -90 -3
+      vertex -157 90 3
+      vertex -157 90 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -157 -90 -3
+      vertex -157 -90 3
+      vertex -157 90 3
+    endloop
+  endfacet
+  facet normal -0.504263 -0.86355 0
+    outer loop
+      vertex -20 -170 -3
+      vertex -157 -90 3
+      vertex -157 -90 -3
+    endloop
+  endfacet
+  facet normal -0.504263 -0.86355 0
+    outer loop
+      vertex -20 -170 -3
+      vertex -20 -170 3
+      vertex -157 -90 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20 -170 -3
+      vertex -20 -170 3
+      vertex -20 -170 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20 -170 -3
+      vertex 20 -170 3
+      vertex -20 -170 3
+    endloop
+  endfacet
+  facet normal 0.508729 -0.860927 0
+    outer loop
+      vertex 130 -105 -3
+      vertex 20 -170 3
+      vertex 20 -170 -3
+    endloop
+  endfacet
+  facet normal 0.508729 -0.860927 0
+    outer loop
+      vertex 130 -105 -3
+      vertex 130 -105 3
+      vertex 20 -170 3
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/turtlebot_description/scripts/plate_simple.scad
+++ b/turtlebot_description/scripts/plate_simple.scad
@@ -1,0 +1,11 @@
+// valid for plates top and middle
+translate([0, 0, -3])
+  linear_extrude(height = 6)
+    polygon([[130, 105], [130, -105], [20, -170], [-20, -170], [-157, -90], [-157, 90], [-20, 170], [20, 170]]);
+
+/* original mesh to compare
+translate([-100, 0, 0])
+  rotate([90, 0, -90])
+    scale(1000)
+      import("../meshes/stacks/hexagons/plate_top.stl", convexity=3);
+*/

--- a/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
+++ b/turtlebot_description/urdf/stacks/hexagons.urdf.xacro
@@ -186,7 +186,8 @@
       <collision>
         <origin xyz="0.01364 0.0 0.0" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="0.006" radius="0.170"/>
+          <mesh filename="package://turtlebot_description/meshes/stacks/hexagons/plate_simple.stl"
+                scale="${M_SCALE} ${M_SCALE} ${M_SCALE}"/>
         </geometry>
       </collision>
       <inertial>
@@ -220,7 +221,8 @@
       <collision>
         <origin xyz="0.01364 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="0.006" radius="0.170"/>
+          <mesh filename="package://turtlebot_description/meshes/stacks/hexagons/plate_simple.stl"
+                scale="${M_SCALE} ${M_SCALE} ${M_SCALE}"/>
         </geometry>
       </collision>
       <inertial>


### PR DESCRIPTION
The cylinder shape prevents TB2 to get very close to small tables for manipulation, for example like in the [block manipulation demo](http://wiki.ros.org/turtlebot_arm_block_manipulation). The mesh almost matches the real plates, but being very simple, I suppose it should not increase much the collisions computation. **Please correct me if that's not the case!!!**

melodic:

![old](https://user-images.githubusercontent.com/322610/96254031-9537e200-0fef-11eb-81f2-26c641a99ae9.png)

PR:

![new](https://user-images.githubusercontent.com/322610/96254148-c1536300-0fef-11eb-9480-9d62b467bac3.png)
