### PR TITLE
Support switching between freenect and OpenNI

### DIFF
--- a/turtlebot_bringup/launch/3dsensor.launch
+++ b/turtlebot_bringup/launch/3dsensor.launch
@@ -40,7 +40,11 @@
   <!-- Laserscan topic -->
   <arg name="scan_topic" default="scan"/>
 
-  <include file="$(find turtlebot_bringup)/launch/includes/3dsensor/$(arg 3d_sensor).launch.xml">
+  <!-- Switch between freenect and OpenNI -->
+  <arg name="use_freenect" default="true"/>
+  <arg     if="$(arg use_freenect)" name="3d_sensor_launch_file" value="$(find freenect_launch)/launch/freenect.launch"/>
+  <arg unless="$(arg use_freenect)" name="3d_sensor_launch_file" value="$(find turtlebot_bringup)/launch/includes/3dsensor/$(arg 3d_sensor).launch.xml"/>
+  <include file="$(arg 3d_sensor_launch_file)">
     <arg name="camera"                          value="$(arg camera)"/>
     <arg name="publish_tf"                      value="$(arg publish_tf)"/>
     <arg name="depth_registration"              value="$(arg depth_registration)"/>

--- a/turtlebot_bringup/package.xml
+++ b/turtlebot_bringup/package.xml
@@ -27,6 +27,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>robot_pose_ekf</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
+  <run_depend>freenect_stack</run_depend>
   <run_depend>openni_launch</run_depend>
   <run_depend>laptop_battery_monitor</run_depend>
   <run_depend>rocon_app_manager</run_depend>


### PR DESCRIPTION
This PR is for supporting the switch between freenect and OpenNI in turtlebot_brigup.

We got the below errors.
We can solve these problems by using freenect instead of OpenNI in this PR.

```bash
~ $ roslaunch turtlebot_bringup 3dsensor.launch
... logging to /home/sktometometo/.ros/log/76cbde5e-e22d-11ec-8685-2079185f8b3d/roslaunch-KI00070-15086.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://KI00070:40915/

SUMMARY
========

PARAMETERS
 * /camera/camera_nodelet_manager/num_worker_threads: 4
 * /camera/depth_rectify_depth/interpolation: 0
 * /camera/depth_registered_rectify_depth/interpolation: 0
 * /camera/disparity_depth/max_range: 4.0
 * /camera/disparity_depth/min_range: 0.5
 * /camera/disparity_registered_hw/max_range: 4.0
 * /camera/disparity_registered_hw/min_range: 0.5
 * /camera/disparity_registered_sw/max_range: 4.0
 * /camera/disparity_registered_sw/min_range: 0.5
 * /camera/driver/depth_camera_info_url:
 * /camera/driver/depth_frame_id: camera_depth_opti...
 * /camera/driver/depth_registration: True
 * /camera/driver/device_id: #1
 * /camera/driver/rgb_camera_info_url:
 * /camera/driver/rgb_frame_id: camera_rgb_optica...
 * /depthimage_to_laserscan/output_frame_id: camera_depth_frame
 * /depthimage_to_laserscan/range_min: 0.45
 * /depthimage_to_laserscan/scan_height: 10
 * /rosdistro: melodic
 * /rosversion: 1.14.13

NODES
  /
    depthimage_to_laserscan (nodelet/nodelet)
  /camera/
    camera_nodelet_manager (nodelet/nodelet)
    depth_metric (nodelet/nodelet)
    depth_metric_rect (nodelet/nodelet)
    depth_points (nodelet/nodelet)
    depth_rectify_depth (nodelet/nodelet)
    depth_registered_hw_metric_rect (nodelet/nodelet)
    depth_registered_metric (nodelet/nodelet)
    depth_registered_rectify_depth (nodelet/nodelet)
    depth_registered_sw_metric_rect (nodelet/nodelet)
    disparity_depth (nodelet/nodelet)
    disparity_registered_hw (nodelet/nodelet)
    disparity_registered_sw (nodelet/nodelet)
    driver (nodelet/nodelet)
    ir_rectify_ir (nodelet/nodelet)
    points_xyzrgb_hw_registered (nodelet/nodelet)
    points_xyzrgb_sw_registered (nodelet/nodelet)
    register_depth_rgb (nodelet/nodelet)
    rgb_debayer (nodelet/nodelet)
    rgb_rectify_color (nodelet/nodelet)
    rgb_rectify_mono (nodelet/nodelet)

ROS_MASTER_URI=http://localhost:11311

process[camera/camera_nodelet_manager-1]: started with pid [15103]
process[camera/driver-2]: started with pid [15104]
process[camera/rgb_debayer-3]: started with pid [15105]
process[camera/rgb_rectify_mono-4]: started with pid [15106]
process[camera/rgb_rectify_color-5]: started with pid [15122]
process[camera/ir_rectify_ir-6]: started with pid [15136]
process[camera/depth_rectify_depth-7]: started with pid [15145]
process[camera/depth_metric_rect-8]: started with pid [15157]
process[camera/depth_metric-9]: started with pid [15179]
process[camera/depth_points-10]: started with pid [15187]
process[camera/register_depth_rgb-11]: started with pid [15199]
process[camera/points_xyzrgb_sw_registered-12]: started with pid [15210]
process[camera/depth_registered_sw_metric_rect-13]: started with pid [15223]
process[camera/depth_registered_rectify_depth-14]: started with pid [15229]
process[camera/points_xyzrgb_hw_registered-15]: started with pid [15248]
process[camera/depth_registered_hw_metric_rect-16]: started with pid [15254]
process[camera/depth_registered_metric-17]: started with pid [15264]
[ INFO] [WallTime: 1654150478.829639824] [node:/camera/camera_nodelet_manager] [func:Loader::Impl::advertiseRosApi]: Initializing nodelet with 4 worker threads.
process[camera/disparity_depth-18]: started with pid [15279]
process[camera/disparity_registered_sw-19]: started with pid [15295]
process[camera/disparity_registered_hw-20]: started with pid [15318]
process[depthimage_to_laserscan-21]: started with pid [15335]
[ INFO] [WallTime: 1654150479.166859103] [node:/camera/camera_nodelet_manager] [func:DriverNodelet::setupDevice]: No devices connected.... waiting for devices to be connected
```

```bash
~ $ rostopic list
/camera/depth_registered/camera_info
/camera/depth_registered/image
/camera/rgb/image_raw
/clicked_point
/initialpose
/map
/map_updates
/move_base/NavfnROS/plan
/move_base_simple/goal
/particlecloud
/rosout
/rosout_agg
/scan
/tf
/tf_static
~ $ rostopic hz /camera/depth_registered/image
subscribed to [/camera/depth_registered/image]
no new messages
no new messages
no new messages
no new messages
```